### PR TITLE
Catch and default

### DIFF
--- a/lib/financeCookies.js
+++ b/lib/financeCookies.js
@@ -49,6 +49,9 @@ function fetch(symbol) {
     .then(function (res) {
       data.crumb = parseAndGetCrumb(res.body);
       storeCookiesInJar(res.headers['set-cookie'], url, cookiejar);
+    })
+    .catch(function(err){
+      console.log(err);
     });
 }
 
@@ -58,7 +61,7 @@ function getCrumb(symbol) {
   // auth refused TODO in index
   if (data.crumb === NEVER_SET) {
     console.log('fetching cookie and crumb');
-    return fetch().then(function() { return data.crumb; })
+    return fetch(symbol).then(function() { return data.crumb; })
   } else {
     console.log('from cache');
     return Promise.resolve(data.crumb);


### PR DESCRIPTION
- Catch exception to prevent fatal error. ( Might not be required with updated dependencies )
- Default the symbol for the url ( prevent it getting the cookie for 'undefined' )